### PR TITLE
fix: amended cert file path to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 # included so mkcert certificates aren't committed to the repository
-/frontend/certs/
+frontend/certs/
+
+**/.env
+


### PR DESCRIPTION
I had to fix the gitignore path for our certs folder. I made an error the first time