### PR TITLE
Fix: prevent redundant rerenders in DirectionsRenderer

### DIFF
--- a/frontend/src/pages/Directions/Directions.jsx
+++ b/frontend/src/pages/Directions/Directions.jsx
@@ -109,12 +109,17 @@ export default function Directions({ userLocation }) {
   // dynamically display station name
   const location = useLocation();
   const selectedStation = location.state?.station;
-  const stationLocation = selectedStation?.coordinates
-    ? {
-        lat: selectedStation.coordinates.latitude,
-        lng: selectedStation.coordinates.longitude,
-      }
-    : null;
+
+  // console.log("selectedStation:", selectedStation);
+  // console.log("selectedStation.coordinates:", selectedStation?.coordinates);
+
+  const stationLocation =
+    selectedStation?.latitude != null && selectedStation?.longitude != null
+      ? {
+          lat: selectedStation.latitude,
+          lng: selectedStation.longitude,
+        }
+      : null;
 
   // debugging tools
   useEffect(() => {
@@ -158,7 +163,9 @@ export default function Directions({ userLocation }) {
             stationLocation
           );
 
-          setDirections(result);
+          setDirections((prev) => {
+            return prev === result ? prev : result;
+          });
         } else {
           console.error("❌ Directions request failed:", result);
         }

--- a/frontend/src/shared/map/Map.jsx
+++ b/frontend/src/shared/map/Map.jsx
@@ -94,6 +94,9 @@ export default function Map({
 
   // Drop station marker
   useEffect(() => {
+    console.log("Validating coords:", stationLocation);
+    console.log("Result:", isValidCoords(stationLocation));
+
     if (!isMapReady || !isValidCoords(stationLocation)) return;
 
     const { lat, lng } = stationLocation;
@@ -104,6 +107,15 @@ export default function Map({
 
     dropMarker({ lat, lng }, "Station");
   }, [stationLocation, isMapReady]);
+
+  // stop direction from going into rendering loop by storing in useRef
+  const directionsRef = useRef(null);
+
+  useEffect(() => {
+    if (directions && !directionsRef.current) {
+      directionsRef.current = directions;
+    }
+  }, [directions]);
 
   return (
     <div style={{ width: "100%", height: "100%" }}>
@@ -122,12 +134,19 @@ export default function Map({
             setIsMapReady(true);
           }}
         >
-          {directions && (
+          {directionsRef.current && (
+            <DirectionsRenderer
+              directions={directionsRef.current}
+              options={{ suppressMarkers: true }}
+            />
+          )}
+
+          {/* {directions && (
             <DirectionsRenderer
               directions={directions}
               options={{ suppressMarkers: true }}
             />
-          )}
+          )} */}
           {/*_______________ FIND STATION MAP MARKERS ________________________
     
           --- Render station marker only inside the /find-station map instance ---


### PR DESCRIPTION
- Added a functional setDirections with strict equality guard (prev === result)
- Preserved previous useRef optimization to stabilize DirectionsRenderer mount